### PR TITLE
Fixes double counting

### DIFF
--- a/octoprint_stats/__init__.py
+++ b/octoprint_stats/__init__.py
@@ -905,7 +905,7 @@ class StatsPlugin(octoprint.plugin.EventHandlerPlugin,
             eventData = {'event_type': 'PRINT_DONE', 
                          'data': {'event_time': datetime.datetime.today().__str__(), 'file': file, 'ptime': ptime, 'origin': origin, 'bed_actual': bed_actual, 'tool0_actual': tool0_actual, 'tool1_actual': tool1_actual, 'tool2_actual': tool2_actual, 'tool0_volume': tool0_volume, 'tool1_volume': tool1_volume, 'tool2_volume': tool2_volume, 'tool0_length': tool0_length, 'tool1_length': tool1_length, 'tool2_length': tool2_length, 'name': name, 'size': size, 'owner': owner}}
 
-        if event == octoprint.events.Events.PRINT_FAILED:
+        if event == octoprint.events.Events.PRINT_FAILED and payload["reason"] == "error":
             if payload["path"] != None:
                 file = payload["path"]
             elif payload["file"] != None:

--- a/octoprint_stats/static/js/stats.js
+++ b/octoprint_stats/static/js/stats.js
@@ -68,7 +68,7 @@ $(function () {
 
         fillColor['ERROR'] = 'rgba(241,196,15,0.5)';
         label['ERROR'] = 'Error';
-        stack['ERROR'] = 'Print';
+        stack['ERROR'] = 'Conn';
 
         fillColor['kwh'] = 'rgba(241,196,15,0.5)';
         label['kwh'] = 'kWh';


### PR DESCRIPTION
1. Alters the definition of "Failures" to exclude "Cancellations" thus stopping the double counting of a cancelled print as both a "Cancellation" and "Failure".
2. Moves the "Errors" from the "Print" stack to the "Conn" stack as it includes errors when a print wasn't in operation. This means that the "Cancelled" + "Complete" + "Failed" = "Started" making more logical sense.